### PR TITLE
Fix stack capture

### DIFF
--- a/src/MRubyCS/Internals/MRubyCallInfo.cs
+++ b/src/MRubyCS/Internals/MRubyCallInfo.cs
@@ -260,7 +260,7 @@ class MRubyContext
         }
 
         // currentCallInfo.
-        CallStack[CallDepth].Clear();
+        currentCallInfo.Clear();
         CallDepth--;
     }
 
@@ -443,7 +443,7 @@ class MRubyContext
     {
         if (callInfo.ArgumentPacked)
         {
-            return Stack[callInfo.StackPointer + 1].As<RArray>().AsSpan();
+            return Stack[callInfo.StackPointer + 1].As<RArray>().AsSpan(startIndex, callInfo.ArgumentCount - startIndex);
         }
         return Stack.AsSpan(callInfo.StackPointer + 1 + startIndex, callInfo.ArgumentCount - startIndex);
     }

--- a/src/MRubyCS/MRubyState.Object.cs
+++ b/src/MRubyCS/MRubyState.Object.cs
@@ -428,7 +428,8 @@ partial class MRubyState
                 env = new REnv
                 {
                     Context = context,
-                    Stack = context.Stack.AsMemory(callInfo.StackPointer, stackSize),
+                    StackPointer = callInfo.StackPointer,
+                    StackSize = stackSize,
                     MethodId = methodId,
                     BlockArgumentOffset = callInfo.BlockArgumentOffset,
                     TargetClass = callInfo.Scope.TargetClass
@@ -452,7 +453,7 @@ partial class MRubyState
                 Raise(Names.ArgumentError, "self is lost (probably ran out of memory when the block became independent)"u8);
             }
             targetClass = env.TargetClass;
-            return env.Stack.Span[0];
+            return env.Stack[0];
         }
 
         targetClass = ObjectClass;
@@ -464,7 +465,7 @@ partial class MRubyState
         ref var callInfo = ref context.CurrentCallInfo;
         if (callInfo.Proc?.Scope is REnv env)
         {
-            return env.Stack.Span;
+            return env.Stack;
         }
         Raise(Names.TypeError, "Can't get closure env from proc"u8);
         return default; // not reached

--- a/src/MRubyCS/MRubyState.Vm.cs
+++ b/src/MRubyCS/MRubyState.Vm.cs
@@ -197,7 +197,7 @@ partial class MRubyState
         var nextStack = context.Stack.AsSpan(nextCallInfo.StackPointer);
         nextStack[0] = self;
 
-        if (args.Length > MRubyCallInfo.CallMaxArgs)
+        if (args.Length >= MRubyCallInfo.CallMaxArgs)
         {
             // TODO: packing
             throw new NotImplementedException();
@@ -209,12 +209,7 @@ partial class MRubyState
         }
         nextCallInfo.KeywordArgumentCount = 0;
 
-        if (block is not { } proc)
-        {
-            throw new NotSupportedException();
-        }
-
-        return Exec(proc.Irep, proc.ProgramCounter, nextCallInfo.BlockArgumentOffset + 1);
+        return Exec(block.Irep, block.ProgramCounter, nextCallInfo.BlockArgumentOffset + 1);
     }
 
     public MRubyValue Exec(ReadOnlySpan<byte> bytecode)

--- a/src/MRubyCS/MRubyState.Vm.cs
+++ b/src/MRubyCS/MRubyState.Vm.cs
@@ -642,7 +642,7 @@ partial class MRubyState
                         var env = callInfo.Proc?.FindUpperEnvTo(bbb.C);
                         if (env != null && bbb.B < env.Stack.Length)
                         {
-                            registers[bbb.A] = env.Stack.Span[bbb.B];
+                            registers[bbb.A] = env.Stack[bbb.B];
                         }
                         else
                         {
@@ -657,7 +657,7 @@ partial class MRubyState
                         var env = callInfo.Proc?.FindUpperEnvTo(bbb.C);
                         if (env != null && bbb.B < env.Stack.Length)
                         {
-                            env.Stack.Span[bbb.B] = registers[bbb.A];
+                            env.Stack[bbb.B] = registers[bbb.A];
                         }
                         goto Next;
                     }
@@ -943,7 +943,7 @@ partial class MRubyState
                         if (proc.Scope is REnv env)
                         {
                             callInfo.MethodId = env.MethodId;
-                            registers[0] = env.Stack.Span[0];
+                            registers[0] = env.Stack[0];
                         }
                         goto Next;
                     }
@@ -987,7 +987,7 @@ partial class MRubyState
                         var aspec = new ArgumentSpec(bits);
 
                         var argc = callInfo.ArgumentCount;
-                        var argv = registers.Slice(1, argc);
+                        var argv = registers[1..];
 
                         var m1 = aspec.MandatoryArguments1Count;
 
@@ -1306,7 +1306,7 @@ partial class MRubyState
                             {
                                 Raise(Names.LocalJumpError, "unexpected yield"u8);
                             }
-                            stack = env!.Stack.Span[1..];
+                            stack = env!.Stack[1..];
                         }
 
                         var block = stack[offset];


### PR DESCRIPTION
Currently, Stack decompression is implemented with Array.Resize. And Closure is trying to keep the Array reference intact.
This has caused problems with Closure not following changes to the Array.