### PR TITLE
VM optimization

### DIFF
--- a/src/MRubyCS/Internals/MRubyCallInfo.cs
+++ b/src/MRubyCS/Internals/MRubyCallInfo.cs
@@ -185,7 +185,7 @@ class MRubyContext
     const int CallDepthMax = 512;
     static int LastId = -1;
 
-    public int CallDepth { get; private set; }
+    public int CallDepth;
     public int Id { get; }
 
     public RFiber? Fiber { get; internal set; }
@@ -515,11 +515,17 @@ class MRubyContext
         return CollectionsMarshal.AsSpan(list);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     void EnsureStackLevel()
     {
         if (CallDepth >= CallDepthMax)
         {
-            throw new InvalidOperationException("stack level too deep");
+            ThrowStacTooDeep();
+        }
+
+        static void ThrowStacTooDeep()
+        {
+            throw new StackOverflowException("stack level too deep");
         }
     }
 }

--- a/src/MRubyCS/Internals/MRubyCallInfo.cs
+++ b/src/MRubyCS/Internals/MRubyCallInfo.cs
@@ -525,7 +525,7 @@ class MRubyContext
 
         static void ThrowStacTooDeep()
         {
-            throw new StackOverflowException("stack level too deep");
+            throw new InvalidOperationException("stack level too deep");
         }
     }
 }

--- a/src/MRubyCS/Internals/SymbolHelpers.cs
+++ b/src/MRubyCS/Internals/SymbolHelpers.cs
@@ -1,0 +1,25 @@
+﻿namespace MRubyCS.Internals;
+
+internal static class SymbolHelpers
+{
+
+    static readonly  Symbol[] OpCodeSymbols =
+    [
+        Names.OpAdd,
+        Names.OpAdd,
+        Names.OpSub,
+        Names.OpSub,
+        Names.OpMul,
+        Names.OpDiv,
+        Names.OpEq,
+        Names.OpLt,
+        Names.OpLe,
+        Names.OpGt,
+        Names.OpGe
+    ];
+
+    public static Symbol GetOpCodeSymbol(OpCode opCode)
+    {
+        return opCode == OpCode.GetIdx ? Names.OpAref : OpCodeSymbols[(int)opCode-(int)OpCode.Add];
+    }
+}

--- a/src/MRubyCS/MRubyState.Vm.cs
+++ b/src/MRubyCS/MRubyState.Vm.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MRubyCS.Internals;
 using MRubyCS.StdLib;
+
 // ReSharper disable UnreachableSwitchArmDueToIntegerAnalysis
 
 namespace MRubyCS;
@@ -1313,7 +1314,7 @@ partial class MRubyState
                             {
                                 registerA = MRubyValue.From(opcode switch
                                 {
-                                    OpCode.Add  => checked(leftInt + rightInt),
+                                    OpCode.Add => checked(leftInt + rightInt),
                                     OpCode.Sub => checked(leftInt - rightInt),
                                     OpCode.Mul => checked(leftInt * rightInt),
                                     OpCode.Div => leftInt / rightInt,
@@ -1369,7 +1370,7 @@ partial class MRubyState
                         callInfo.StackPointer = nextStackPointer;
                         callInfo.MethodId = opcode switch
                         {
-                            OpCode.Add  => Names.OpAdd,
+                            OpCode.Add => Names.OpAdd,
                             OpCode.Sub => Names.OpSub,
                             OpCode.Mul => Names.OpMul,
                             OpCode.Div => Names.OpDiv,
@@ -1415,172 +1416,86 @@ partial class MRubyState
                         goto case OpCode.SendInternal;
                     }
                     case OpCode.EQ:
-                    {
-                        Markers.EQ();
-                        a = ReadOperandB(sequence, ref callInfo.ProgramCounter);
-                        registerA = ref registers[a];
-                        rhs = Unsafe.Add(ref registerA, 1);
-                        if (registerA.Equals(rhs))
-                        {
-                            registerA = MRubyValue.True;
-                            goto Next;
-                        }
-                        if (registerA.IsSymbol)
-                        {
-                            registerA = MRubyValue.False;
-                            goto Next;
-                        }
-                        switch (registerA.VType, rhs.VType)
-                        {
-                            case (MRubyVType.Integer, MRubyVType.Integer):
-                                registerA = MRubyValue.From(registerA.IntegerValue == rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Integer, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.IntegerValue == (long)rhs.FloatValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Integer):
-                                registerA = MRubyValue.From((long)registerA.FloatValue == rhs.IntegerValue);
-                                goto Next;
-                            // ReSharper disable once CompareOfFloatsByEqualityOperator
-                            case (MRubyVType.Float, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.FloatValue == rhs.FloatValue);
-                                goto Next;
-                        }
-
-                        // Jump to send :==
-                        var nextStackPointer = callInfo.StackPointer + a;
-                        callInfo = ref Context.PushCallStack();
-                        callInfo.CallerType = CallerType.InVmLoop;
-                        callInfo.StackPointer = nextStackPointer;
-                        callInfo.MethodId = Names.OpEq;
-                        callInfo.ArgumentCount = 1;
-                        callInfo.KeywordArgumentCount = 0;
-                        goto case OpCode.SendInternal;
-                    }
                     case OpCode.LT:
-                    {
-                        Markers.LT();
-                        a = ReadOperandB(sequence, ref callInfo.ProgramCounter);
-                        registerA = ref registers[a];
-                        rhs = Unsafe.Add(ref registerA, 1);
-                        switch (registerA.VType, rhs.VType)
-                        {
-                            case (MRubyVType.Integer, MRubyVType.Integer):
-                                registerA = MRubyValue.From(registerA.IntegerValue < rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Integer, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.IntegerValue < (long)rhs.FloatValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Integer):
-                                registerA = MRubyValue.From((long)registerA.FloatValue < rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.FloatValue < rhs.FloatValue);
-                                goto Next;
-                        }
-
-                        // Jump to send :==
-                        var nextStackPointer = callInfo.StackPointer + a;
-                        callInfo = ref Context.PushCallStack();
-                        callInfo.CallerType = CallerType.InVmLoop;
-                        callInfo.StackPointer = nextStackPointer;
-                        callInfo.MethodId = Names.OpLt;
-                        callInfo.ArgumentCount = 1;
-                        callInfo.KeywordArgumentCount = 0;
-                        goto case OpCode.SendInternal;
-                    }
                     case OpCode.LE:
-                    {
-                        Markers.LE();
-                        a = ReadOperandB(sequence, ref callInfo.ProgramCounter);
-                        registerA = ref registers[a];
-                        rhs = Unsafe.Add(ref registerA, 1);
-
-                        switch (registerA.VType, rhs.VType)
-                        {
-                            case (MRubyVType.Integer, MRubyVType.Integer):
-                                registerA = MRubyValue.From(registerA.IntegerValue <= rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Integer, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.IntegerValue <= (long)rhs.FloatValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Integer):
-                                registerA = MRubyValue.From((long)registerA.FloatValue <= rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.FloatValue <= rhs.FloatValue);
-                                goto Next;
-                        }
-
-                        // Jump to send :<=
-                        var nextStackPointer = callInfo.StackPointer + a;
-                        callInfo = ref Context.PushCallStack();
-                        callInfo.CallerType = CallerType.InVmLoop;
-                        callInfo.StackPointer = nextStackPointer;
-                        callInfo.MethodId = Names.OpLe;
-                        callInfo.ArgumentCount = 1;
-                        callInfo.KeywordArgumentCount = 0;
-                        goto case OpCode.SendInternal;
-                    }
                     case OpCode.GT:
-                    {
-                        Markers.GT();
-                        a = ReadOperandB(sequence, ref callInfo.ProgramCounter);
-                        registerA = ref registers[a];
-                        rhs = Unsafe.Add(ref registerA, 1);
-
-                        switch (registerA.VType, rhs.VType)
-                        {
-                            case (MRubyVType.Integer, MRubyVType.Integer):
-                                registerA = MRubyValue.From(registerA.IntegerValue > rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Integer, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.IntegerValue > (long)rhs.FloatValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Integer):
-                                registerA = MRubyValue.From((long)registerA.FloatValue > rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.FloatValue > rhs.FloatValue);
-                                goto Next;
-                        }
-                        // Jump to send :>
-                        var nextStackPointer = callInfo.StackPointer + a;
-                        callInfo = ref Context.PushCallStack();
-                        callInfo.CallerType = CallerType.InVmLoop;
-                        callInfo.StackPointer = nextStackPointer;
-                        callInfo.MethodId = Names.OpGt;
-                        callInfo.ArgumentCount = 1;
-                        callInfo.KeywordArgumentCount = 0;
-                        goto case OpCode.SendInternal;
-                    }
                     case OpCode.GE:
-                    {
+                        Markers.EQ();
+                        Markers.LT();
+                        Markers.LE();
+                        Markers.GT();
                         Markers.GE();
                         a = ReadOperandB(sequence, ref callInfo.ProgramCounter);
                         registerA = ref registers[a];
                         rhs = Unsafe.Add(ref registerA, 1);
-                        switch (registerA.VType, rhs.VType)
+
+                        if (opcode == OpCode.EQ)
                         {
-                            case (MRubyVType.Integer, MRubyVType.Integer):
-                                registerA = MRubyValue.From(registerA.IntegerValue >= rhs.IntegerValue);
+                            if (registerA.Equals(rhs))
+                            {
+                                registerA = MRubyValue.True;
                                 goto Next;
-                            case (MRubyVType.Integer, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.IntegerValue >= (long)rhs.FloatValue);
+                            }
+                            if (registerA.IsSymbol)
+                            {
+                                registerA = MRubyValue.False;
                                 goto Next;
-                            case (MRubyVType.Float, MRubyVType.Integer):
-                                registerA = MRubyValue.From((long)registerA.FloatValue >= rhs.IntegerValue);
-                                goto Next;
-                            case (MRubyVType.Float, MRubyVType.Float):
-                                registerA = MRubyValue.From(registerA.FloatValue >= rhs.FloatValue);
-                                goto Next;
+                            }
                         }
-                        // Jump to send :>=
+
+                        lhsVType = registerA.VType;
+                        rhsVType = rhs.VType;
+
+                        if (lhsVType == MRubyVType.Float && rhsVType == MRubyVType.Float)
+                        {
+                            var leftVal = registerA.FloatValue;
+                            var rightVal = rhs.FloatValue;
+                            registerA = MRubyValue.From(opcode switch
+                            {
+                                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                                OpCode.EQ => leftVal == rightVal,
+                                OpCode.LT => leftVal < rightVal,
+                                OpCode.LE => leftVal <= rightVal,
+                                OpCode.GT => leftVal > rightVal,
+                                OpCode.GE => leftVal >= rightVal,
+                                _ => false
+                            });
+                            goto Next;
+                        }
+
+                        if (lhsVType is MRubyVType.Integer or MRubyVType.Float &&
+                            rhsVType is MRubyVType.Integer or MRubyVType.Float)
+                        {
+                            var leftVal = lhsVType == MRubyVType.Integer ? registerA.IntegerValue : (long)registerA.FloatValue;
+                            var rightVal = rhsVType == MRubyVType.Integer ? rhs.IntegerValue : (long)rhs.FloatValue;
+                            {
+                                registerA = MRubyValue.From(opcode switch
+                                {
+                                    OpCode.EQ => leftVal == rightVal,
+                                    OpCode.LT => leftVal < rightVal,
+                                    OpCode.LE => leftVal <= rightVal,
+                                    OpCode.GT => leftVal > rightVal,
+                                    OpCode.GE => leftVal >= rightVal,
+                                    _ => false
+                                });
+                            }
+                            goto Next;
+                        }
+                    {
+                        // Jump to send method
                         var nextStackPointer = callInfo.StackPointer + a;
                         callInfo = ref Context.PushCallStack();
                         callInfo.CallerType = CallerType.InVmLoop;
                         callInfo.StackPointer = nextStackPointer;
-                        callInfo.MethodId = Names.OpGe;
+                        callInfo.MethodId = opcode switch
+                        {
+                            OpCode.EQ => Names.OpEq,
+                            OpCode.LT => Names.OpLt,
+                            OpCode.LE => Names.OpLe,
+                            OpCode.GT => Names.OpGt,
+                            OpCode.GE => Names.OpGe,
+                            _ => default
+                        };
                         callInfo.ArgumentCount = 1;
                         callInfo.KeywordArgumentCount = 0;
                         goto case OpCode.SendInternal;

--- a/src/MRubyCS/Symbol.cs
+++ b/src/MRubyCS/Symbol.cs
@@ -7,6 +7,7 @@ namespace MRubyCS;
 public readonly record struct Symbol(uint Value)
 {
     public static readonly Symbol Empty = new(0);
+    public readonly uint Value = Value;
 }
 
 class SymbolTable


### PR DESCRIPTION
The machine language(×64
intel) byte length of the VM loop method was reduced.
It may slow down in some cases, but overall this speeded up the process.
| MethodSize (byte)| 
|------------ |
| 28940  | 
| 20171| 

## Loop Bench
```lua
a = 0.1
while a < 100000
  a += 1
  a -= 0.1
  a *= 1.001
  a /= 1.001
end
```
| Method      | Mean     | Error     | StdDev    | Allocated |
|------------ |---------:|----------:|----------:|----------:|
| MRubyCS     | 3.084 ms | 0.0158 ms | 0.0105 ms |     176 B |
| MRubyCS(PR)  | 2.661 ms | 0.0035 ms | 0.0018 ms |     176 B |
 MRubyNative | 4.393 ms | 0.0186 ms | 0.0123 ms |       1 B |

## Fib Bench
```lua
def fib n
  return n if n < 2
  fib(n-2) + fib(n-1)
end
fib(20)
```
| Method      | Mean       | Error    | StdDev  | Allocated |
|------------ |-----------:|---------:|--------:|----------:|
| MRubyCS     | 2,051.7 us | 9.65 us | 6.38 us |     354 B |
| MRubyCS(PR) | 1,897.8 us | 10.16 us | 6.72 us |     353 B |
| MRubyNative |   576.6 us |  1.49 us | 0.99 us |         - |