### PR TITLE
Revert MRuby value implementation “TypeObjectUnion"

### DIFF
--- a/src/MRubyCS/MRubyState.Init.cs
+++ b/src/MRubyCS/MRubyState.Init.cs
@@ -103,17 +103,17 @@ public partial class MRubyState
 
     void InitClass()
     {
-        BasicObjectClass = new RClass(ClassClass)
+        BasicObjectClass = new RClass(default!)
         {
             InstanceVType = MRubyVType.Undef,
             Super = default!, // sentinel. only for BasicObject
         };
-        ObjectClass = new RClass(ClassClass)
+        ObjectClass = new RClass(default!)
         {
             InstanceVType = MRubyVType.Object,
             Super = BasicObjectClass,
         };
-        ModuleClass = new RClass(ClassClass)
+        ModuleClass = new RClass(default!)
         {
             InstanceVType = MRubyVType.Module,
             Super = ObjectClass,
@@ -380,8 +380,8 @@ public partial class MRubyState
         DefineMethod(IntegerClass, Names.Hash, IntegerMembers.Hash);
         DefineMethod(IntegerClass, Intern("divmod"u8), IntegerMembers.DivMod);
         DefineMethod(IntegerClass, Intern("to_f"u8), IntegerMembers.ToF);
-        DefineMethod(IntegerClass, Names.ToI, IntegerMembers.ToI);
-        DefineMethod(IntegerClass, Intern("to_int"u8), IntegerMembers.ToI);
+        DefineMethod(IntegerClass, Names.ToI, MRubyMethod.Identity);
+        DefineMethod(IntegerClass, Intern("to_int"u8), MRubyMethod.Identity);
         DefineMethod(IntegerClass, Names.OpAnd, IntegerMembers.OpAnd);
         DefineMethod(IntegerClass, Names.OpOr, IntegerMembers.OpOr);
         DefineMethod(IntegerClass, Names.OpXor, IntegerMembers.OpXor);

--- a/src/MRubyCS/MRubyState.Object.cs
+++ b/src/MRubyCS/MRubyState.Object.cs
@@ -34,6 +34,19 @@ partial class MRubyState
         ValueEqualityComparer,
         HashClass);
 
+    /// <summary>
+    /// Returns an integer MRubyValue. The only difference from new MRubyValue() is that the full 64-bit digit count is available.
+    /// </summary>
+    public MRubyValue NewIntegerFlex(long value)
+    {
+        if (value <= MRubyValue.FixnumMax &&
+            value >= MRubyValue.FixnumMin)
+        {
+            return new MRubyValue(value);
+        }
+        return new RInteger(value, IntegerClass);
+    }
+
     public Symbol ToSymbol(MRubyValue value)
     {
         if (value.IsSymbol) return value.SymbolValue;

--- a/src/MRubyCS/MRubyState.Vm.cs
+++ b/src/MRubyCS/MRubyState.Vm.cs
@@ -403,7 +403,7 @@ partial class MRubyState
                     case OpCode.LoadI32:
                         Markers.LoadI32();
                         var bss = OperandBSS.Read(sequence, ref callInfo.ProgramCounter);
-                        registers[bss.A] = (bss.B << 16) + bss.C;
+                        registers[bss.A] = NewIntegerFlex((bss.B << 16) + bss.C);
                         goto Next;
                     case OpCode.LoadSym:
                         Markers.LoadSym();
@@ -553,7 +553,7 @@ partial class MRubyState
                         switch (registerA.Object)
                         {
                             case RArray array when valueB.IsInteger:
-                                registerA = array[(int)valueB.bits];
+                                registerA = array[(int)valueB.IntegerValue];
                                 goto Next;
                             case RHash hash:
                                 registerA = hash.GetValueOrDefault(valueB, this);
@@ -728,7 +728,7 @@ partial class MRubyState
                                     }
                                     case BreakTag.Jump:
                                     {
-                                        var newProgramCounter = (int)breakObject.Value.bits;
+                                        var newProgramCounter = (int)breakObject.Value.IntegerValue;
                                         if (irep.TryFindCatchHandler(callInfo.ProgramCounter, CatchHandlerType.Ensure, out var catchHandler))
                                         {
                                             // avoiding a jump from a catch handler into the same handler
@@ -1371,8 +1371,8 @@ partial class MRubyState
                         var rhsVType = rhs.VType;
                         if (lhsVType == MRubyVType.Integer && rhsVType == MRubyVType.Integer)
                         {
-                            var leftInt = registerA.bits;
-                            var rightInt = rhs.bits;
+                            var leftInt = registerA.IntegerValue;
+                            var rightInt = rhs.IntegerValue;
                             try
                             {
                                 registerA = new MRubyValue(opcode switch
@@ -1405,8 +1405,8 @@ partial class MRubyState
                         if (lhsVType is MRubyVType.Integer or MRubyVType.Float &&
                             rhsVType is MRubyVType.Integer or MRubyVType.Float)
                         {
-                            var leftVal = lhsVType == MRubyVType.Integer ? registerA.bits : registerA.FloatValue;
-                            var rightVal = rhsVType == MRubyVType.Integer ? rhs.bits : rhs.FloatValue;
+                            var leftVal = lhsVType == MRubyVType.Integer ? registerA.IntegerValue : registerA.FloatValue;
+                            var rightVal = rhsVType == MRubyVType.Integer ? rhs.IntegerValue : rhs.FloatValue;
 
                             registerA = new MRubyValue(opcode switch
                             {
@@ -1442,7 +1442,7 @@ partial class MRubyState
                             case MRubyVType.Integer:
                                 try
                                 {
-                                    registerA = checked(registerA.bits + rV);
+                                    registerA = checked(registerA.IntegerValue + rV);
                                 }
                                 catch (OverflowException)
                                 {
@@ -1510,8 +1510,8 @@ partial class MRubyState
                         if (lhsVType is MRubyVType.Integer or MRubyVType.Float &&
                             rhsVType is MRubyVType.Integer or MRubyVType.Float)
                         {
-                            var leftVal = lhsVType == MRubyVType.Integer ? registerA.bits : (long)registerA.FloatValue;
-                            var rightVal = rhsVType == MRubyVType.Integer ? rhs.bits : (long)rhs.FloatValue;
+                            var leftVal = lhsVType == MRubyVType.Integer ? registerA.IntegerValue : (long)registerA.FloatValue;
+                            var rightVal = rhsVType == MRubyVType.Integer ? rhs.IntegerValue : (long)rhs.FloatValue;
                             {
                                 registerA = new MRubyValue(opcode switch
                                 {

--- a/src/MRubyCS/RInteger.cs
+++ b/src/MRubyCS/RInteger.cs
@@ -2,9 +2,9 @@ namespace MRubyCS;
 
 public sealed class RInteger : RObject
 {
-    public nint Value { get; }
+    public long Value { get; }
 
-    internal RInteger(nint value, RClass integerClass) : base(MRubyVType.Integer, integerClass)
+    internal RInteger(long value, RClass integerClass) : base(MRubyVType.Integer, integerClass)
     {
         Value = value;
     }

--- a/src/MRubyCS/RiteParser.cs
+++ b/src/MRubyCS/RiteParser.cs
@@ -236,7 +236,7 @@ public class RiteParser(MRubyState state)
                     {
                         var x = BinaryPrimitives.ReadInt32BigEndian(bin);
                         bin = bin[sizeof(int)..];
-                        poolingValues[i] = MRubyValue.From(x);
+                        poolingValues[i] = x;
                         break;
                     }
                     // Int64
@@ -244,7 +244,7 @@ public class RiteParser(MRubyState state)
                     {
                         var x = BinaryPrimitives.ReadInt64BigEndian(bin);
                         bin = bin[sizeof(long)..];
-                        poolingValues[i] = MRubyValue.From(x);
+                        poolingValues[i] = state.NewIntegerFlex(x);
                         break;
                     }
                     // BigInt

--- a/src/MRubyCS/StdLib/BasicObjectMembers.cs
+++ b/src/MRubyCS/StdLib/BasicObjectMembers.cs
@@ -8,12 +8,12 @@ static class BasicObjectMembers
     [MRubyMethod(RequiredArguments = 1)]
     public static MRubyMethod OpEq = new((state, self) =>
     {
-        return MRubyValue.From(self == state.GetArgumentAt(0));
+        return self == state.GetArgumentAt(0);
     });
 
     public static MRubyMethod Id = new((state, self) =>
     {
-        return MRubyValue.From(self.ObjectId);
+        return self.ObjectId;
     });
 
     public static MRubyMethod Send = new((state, self) =>
@@ -31,7 +31,7 @@ static class BasicObjectMembers
     {
         var methodId = state.GetArgumentAsSymbolAt(0);
         var args = state.GetRestArgumentsAfter(1);
-        var array = MRubyValue.From(state.NewArray(args));
+        var array = state.NewArray(args);
         state.RaiseMethodMissing(methodId, self, array);
         return MRubyValue.Nil;
     });

--- a/src/MRubyCS/StdLib/FloatMembers.cs
+++ b/src/MRubyCS/StdLib/FloatMembers.cs
@@ -16,7 +16,7 @@ static class FloatMembers
 
         if (f > 0.0) return (long)Math.Floor(f);
         if (f < 0.0) return (long)Math.Ceiling(f);
-        return (long)f;
+        return state.NewIntegerFlex((long)f);
     });
 
     public static MRubyMethod ToS = new((state, self) =>

--- a/src/MRubyCS/StdLib/IntegerMembers.cs
+++ b/src/MRubyCS/StdLib/IntegerMembers.cs
@@ -464,8 +464,7 @@ static class IntegerMembers
         return FloatMembers.DivMod.Invoke(state, self);
     });
 
-    public static MRubyMethod ToF = new((state, self) => (double)(state.ToInteger(self)));
-    public static MRubyMethod ToI = new((state, self) => self);
+    public static MRubyMethod ToF = new((state, self) => (double)state.ToInteger(self));
 
     internal static bool NumShift(MRubyState state, long val, long width, out long num)
     {


### PR DESCRIPTION
Unfortunately, the current MRubyValue implementation appears to have issues in the Unity environment.

Therefore, I will revert the MRubyValue implementation back to the bitwise operation method used prior to #12 .

I apologize that this revert will undo some optimizations made by @Akeit0, but for now, I will prioritize resolving the operational issues.

## Problem Details

The issue appears to be that MRubyValue objects holding immediate values remain reachable from the GC-managed heap.

### Pattern 1: Crash unity editor

The scene containing the following MonoBehaviour crashed when Play Mode was started.

```cs
class SampleBehaviour : MonoBehaviour
{
    MRubyValue[] values = new MRubyValue[] { new(12345) };
}
```

- This is likely related to the serialization process of UnityEngine.Object. 

### Pattern2 : Editor hang up

After starting Play Mode in a scene containing the following MonoBehaviour, the editor froze when stopping Play Mode.

```cs
class SampleBehaviour : MonoBehaviour
{
    async void Start()
    {
        var values = new MRubyValue[] { new(12345) };

       // Use this implementation
       // https://github.com/Cysharp/ValueTaskSupplement/blob/master/src/ValueTaskSupplement/ValueTaskEx.WhenAll_Array_NonGenerics.cs
        await ValueTaskEx.WhenAll(new ValueTask[]
        {
            new ValueTask(Task.Delay(TimeSpan.FromSeconds(10), cancellationToken: destroyCancellationToken))
        });
    }
}
```

- In this example, we can still execute Play.
- When the destroyCancellationToken enters a canceled state, IValueTaskSource executes SynchronizationContext.Post. However, because the main thread is blocked, the ValueTask does not complete. The editor continues to wait for the Task to finish, preventing Play mode from stopping.

