### PR TITLE
Fix bootstrap RStrings' class assignment

### DIFF
--- a/src/MRubyCS/MRubyState.Init.cs
+++ b/src/MRubyCS/MRubyState.Init.cs
@@ -494,6 +494,24 @@ public partial class MRubyState : IDisposable
             state.NewString("UTF-8"u8));
 
         StringClass = DefineClass(Intern("String"u8), ObjectClass, MRubyVType.String);
+
+        // Early bootstrap (in InitClass) calls NewString before StringClass exists,
+        // producing RStrings cached on BasicObject/Object/Module/Class with Class == null.
+        // Patch them up now that StringClass is available so later Class#to_s + Send works.
+        FixupBootstrapClassName(BasicObjectClass);
+        FixupBootstrapClassName(ObjectClass);
+        FixupBootstrapClassName(ModuleClass);
+        FixupBootstrapClassName(ClassClass);
+
+        void FixupBootstrapClassName(RClass klass)
+        {
+            if (klass.InstanceVariables.TryGet(Names.ClassNameKey, out var v) &&
+                v.Object is RString str && str.Class == null!)
+            {
+                str.Class = StringClass;
+            }
+        }
+
         DefineMethod(StringClass, Names.Initialize, StringMembers.Initialize);
         DefineMethod(StringClass, Names.InitializeCopy, StringMembers.InitializeCopy);
         DefineMethod(StringClass, Names.OpEq, StringMembers.OpEq);

--- a/tests/MRubyCS.Tests/BootstrapClassNameTest.cs
+++ b/tests/MRubyCS.Tests/BootstrapClassNameTest.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using MRubyCS.Compiler;
+
+namespace MRubyCS.Tests;
+
+/// <summary>
+/// Pins down the fix for the bootstrap class-name RStrings.
+///
+/// During <c>InitClass</c> the runtime calls <c>NewString("Object"u8)</c> etc. to set
+/// up <see cref="MRubyState.ObjectClass"/> / BasicObject / Module / Class names, but
+/// <see cref="MRubyState.StringClass"/> hasn't been defined yet at that point, so the
+/// resulting RStrings end up with <c>Class == null</c>. They get returned to user
+/// code by <c>Class#to_s</c> and any subsequent <c>Send</c> on them would NRE when
+/// the dispatcher tried <c>ClassOf(self).TryFindMethod(...)</c>.
+/// </summary>
+[TestFixture]
+public class BootstrapClassNameTest
+{
+    MRubyState mrb = default!;
+    MRubyCompiler compiler = default!;
+
+    [SetUp]
+    public void BeforeEach()
+    {
+        mrb = MRubyState.Create();
+        compiler = MRubyCompiler.Create(mrb);
+    }
+
+    [TearDown]
+    public void AfterEach()
+    {
+        compiler.Dispose();
+        mrb.Dispose();
+    }
+
+    [Test]
+    public void ObjectClassToS_ResultHasStringClass()
+    {
+        var result = compiler.LoadSourceCode("self.class.to_s"u8);
+        Assert.That(result.Object, Is.InstanceOf<RString>());
+        var str = result.As<RString>();
+        Assert.That(str.Class, Is.Not.Null, "Class#to_s result must carry the StringClass reference");
+        Assert.That(str.Class, Is.SameAs(mrb.StringClass));
+    }
+
+    [Test]
+    public void SendOnClassToSResult_DoesNotNRE()
+    {
+        // The original symptom: NullReferenceException in MRubyState.Send when looking up
+        // a method on the string returned by Class#to_s.
+        var result = compiler.LoadSourceCode("self.class.to_s.length"u8);
+        Assert.That(result.IntegerValue, Is.EqualTo(6)); // "Object".length
+    }
+
+    [Test]
+    public void InspectStringReturnedByClassToS()
+    {
+        var result = compiler.LoadSourceCode("self.class.to_s"u8);
+        var inspected = mrb.Inspect(result);
+        var text = Encoding.UTF8.GetString(inspected.AsSpan());
+        Assert.That(text, Is.EqualTo("\"Object\""));
+    }
+}


### PR DESCRIPTION
- Add unit tests to verify `Class#to_s` behavior during early runtime initialization.
- Fix `RString` instances created during bootstrap to ensure they reference `StringClass`.