### PR TITLE
ggImprove MRubyRaiseException.ToString()

### DIFF
--- a/src/MRubyCS/IrepDebugInfo.cs
+++ b/src/MRubyCS/IrepDebugInfo.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace MRubyCS;
 
-/// <summary>Format of the per-pc line table inside an <see cref="IrepDebugInfoFile"/>.</summary>
+/// <summary>Format of the per-pc line table inside an <see cref="IrepDebugInfoFileEntry"/>.</summary>
 public enum DebugLineType : byte
 {
     /// <summary>One <see cref="ushort"/> per pc (legacy, rarely emitted).</summary>
@@ -24,8 +24,8 @@ public sealed class IrepDebugInfo
     /// <summary>Number of bytecode positions covered by this debug info (typically <c>Irep.Sequence.Length</c>).</summary>
     public uint PcCount { get; init; }
 
-    /// <summary>File entries covering disjoint pc ranges of this Irep. Sorted by <see cref="IrepDebugInfoFile.StartPos"/> ascending.</summary>
-    public IrepDebugInfoFile[] Files { get; init; } = [];
+    /// <summary>File entries covering disjoint pc ranges of this Irep. Sorted by <see cref="IrepDebugInfoFileEntry.StartPos"/> ascending.</summary>
+    public IrepDebugInfoFileEntry[] Files { get; init; } = [];
 
     /// <summary>Look up the source line for a given program counter. Returns -1 if no entry covers it.</summary>
     public int FindLine(int pc)
@@ -53,10 +53,10 @@ public sealed class IrepDebugInfo
     }
 
     /// <summary>
-    /// Binary-search-style lookup for the <see cref="IrepDebugInfoFile"/> whose pc-range
+    /// Binary-search-style lookup for the <see cref="IrepDebugInfoFileEntry"/> whose pc-range
     /// covers <paramref name="pc"/>. Mirrors the algorithm used by mruby's <c>debug.c</c>.
     /// </summary>
-    public IrepDebugInfoFile? FindFile(int pc)
+    public IrepDebugInfoFileEntry? FindFile(int pc)
     {
         if (pc < 0 || pc >= PcCount || Files.Length == 0) return null;
         // Upper-bound search: find the last file whose StartPos <= pc.
@@ -78,7 +78,7 @@ public sealed class IrepDebugInfo
 /// One Irep may contain multiple of these if a single function body was assembled from
 /// several source files (extremely rare in mruby; the common case is one entry per Irep).
 /// </summary>
-public sealed class IrepDebugInfoFile
+public sealed class IrepDebugInfoFileEntry
 {
     /// <summary>Inclusive pc at which this file entry starts being authoritative.</summary>
     public uint StartPos { get; init; }

--- a/src/MRubyCS/MRubyState.Error.cs
+++ b/src/MRubyCS/MRubyState.Error.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using MRubyCS.Internals;
 using Utf8StringInterpolation;
 
@@ -32,6 +33,34 @@ public class MRubyRaiseException(
         int callDepth)
         : this(exceptionObject.Message?.ToString() ?? "exception raised", state, exceptionObject, callDepth)
     {
+    }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.Append(GetType().FullName);
+        sb.Append(": ");
+        sb.Append(Message);
+
+        if (ExceptionObject.Backtrace is { Entries.Count: > 0 } bt)
+        {
+            var trace = bt.ToString(State);
+            sb.AppendLine();
+            sb.Append("mruby backtrace:");
+            foreach (var line in trace.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+            {
+                sb.AppendLine();
+                sb.Append("\tfrom ");
+                sb.Append(line);
+            }
+        }
+
+        if (StackTrace is { } st)
+        {
+            sb.AppendLine();
+            sb.Append(st);
+        }
+        return sb.ToString();
     }
 }
 

--- a/src/MRubyCS/RiteParser.cs
+++ b/src/MRubyCS/RiteParser.cs
@@ -182,7 +182,7 @@ public class RiteParser(MRubyState state)
         var flen = BinaryPrimitives.ReadUInt16BigEndian(bin);
         bin = bin[sizeof(ushort)..];
 
-        var files = new IrepDebugInfoFile[flen];
+        var files = new IrepDebugInfoFileEntry[flen];
         for (var f = 0; f < flen; f++)
         {
             var startPos = BinaryPrimitives.ReadUInt32BigEndian(bin);
@@ -225,7 +225,7 @@ public class RiteParser(MRubyState state)
                     throw new RiteParseException($"unknown debug line type {(byte)lineType}");
             }
 
-            files[f] = new IrepDebugInfoFile
+            files[f] = new IrepDebugInfoFileEntry
             {
                 StartPos = startPos,
                 Filename = (uint)fnameIdx < (uint)filenames.Length ? filenames[fnameIdx] : "",

--- a/tests/MRubyCS.Tests/ExceptionBacktraceTest.cs
+++ b/tests/MRubyCS.Tests/ExceptionBacktraceTest.cs
@@ -70,6 +70,25 @@ public class ExceptionBacktraceTest
     }
 
     [Test]
+    public void MRubyRaiseException_ToString_IncludesMRubyBacktrace()
+    {
+        var ex = Run(Encoding.UTF8.GetBytes("""
+            def deep
+              raise "boom"
+            end
+            deep
+            """), "tostring.rb");
+
+        var text = ex.ToString();
+        TestContext.Out.WriteLine(text);
+
+        Assert.That(text, Does.Contain(nameof(MRubyRaiseException)));
+        Assert.That(text, Does.Contain("mruby backtrace:"));
+        Assert.That(text, Does.Contain("\tfrom tostring.rb:2:in `deep'"));
+        Assert.That(text, Does.Contain("tostring.rb:4:in `<main>'"));
+    }
+
+    [Test]
     public void BacktraceIncludesCallSiteLine_NotMerelyProcStart()
     {
         // Pre-existing bug: Backtrace.Capture used proc.ProgramCounter (always the


### PR DESCRIPTION
## Before
                                                                                                                                                                                                      
```                                                                                                                                                                                                                              
  MRubyCS.MRubyRaiseException: boom (RuntimeError)                                                                                                                                                                            
     at MRubyCS.MRubyState.Raise(RException ex) in /Users/hadashi/dev/MRubyCS/src/MRubyCS/MRubyState.Error.cs:line 59                                                                                                         
     at MRubyCS.MRubyState.Raise(RClass exceptionClass, RString message) in /Users/hadashi/dev/MRubyCS/src/MRubyCS/MRubyState.Error.cs:line 70                                                                                
     at MRubyCS.MRubyState.Raise(Symbol errorType, RString message) in /Users/hadashi/dev/MRubyCS/src/MRubyCS/MRubyState.Error.cs:line 89                                                                                     
     at MRubyCS.StdLib.KernelMembers.<>c.<.cctor>b__25_3(MRubyState state, MRubyValue self) in /Users/hadashi/dev/MRubyCS/src/MRubyCS/StdLib/KernelMembers.cs:line 71                                                         
     at MRubyCS.MRubyState.<Execute>g__CallCSharpFunc|327_17(...) in MRubyState.Vm.cs:line 1596                                                                                                                               
     at MRubyCS.MRubyState.Execute(Irep irep, Int32 pc, Int32 stackKeep, RException injectedRaise) in MRubyState.Vm.cs:line 1583                                                                                              
     at MRubyCS.MRubyState.Execute(Irep irep) in MRubyState.Vm.cs:line 283                                                                                                                                                    
     at MRubyCS.MRubyState.LoadBytecode(ReadOnlySpan`1 bytecode) in MRubyState.Vm.cs:line 250                                                                                                                                 
     ...                                                                                                                                                                                                                      
```                                                                                                                                                                                                                              
                  
##  After
                  
```
  MRubyCS.MRubyRaiseException: boom (RuntimeError)
  mruby backtrace:
        from in `raise'                                                                                                                                                                                                       
        from tostring.rb:2:in `deep'
        from tostring.rb:4:in `<main>'                                                                                                                                                                                        
     at MRubyCS.MRubyState.Raise(RException ex) in /Users/hadashi/dev/MRubyCS/src/MRubyCS/MRubyState.Error.cs:line 88
     at MRubyCS.MRubyState.Raise(RClass exceptionClass, RString message) in MRubyState.Error.cs:line 99                                                                                                                       
     at MRubyCS.MRubyState.Raise(Symbol errorType, RString message) in MRubyState.Error.cs:line 118                                                                                                                           
     at MRubyCS.StdLib.KernelMembers.<>c.<.cctor>b__25_3(...) in KernelMembers.cs:line 71                                                                                                                                     
     at MRubyCS.MRubyState.<Execute>g__CallCSharpFunc|327_17(...) in MRubyState.Vm.cs:line 1596                                                                                                                               
     at MRubyCS.MRubyState.Execute(...) in MRubyState.Vm.cs:line 1583                                                                                                                                                         
     at MRubyCS.MRubyState.Execute(Irep irep) in MRubyState.Vm.cs:line 283                                                                                                                                                    
     at MRubyCS.MRubyState.LoadBytecode(ReadOnlySpan`1 bytecode) in MRubyState.Vm.cs:line 250                                                                                                                                 
     ...                                                                                                                                                                                                                      
```                                      